### PR TITLE
Updates to use latest xalan encryption namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ Next generate the secure environment specific data.\
 The script shows how to convert keystores and secrets to the Curity Identity Server's secure format:
 
 ```bash
-export IDSVR_HOME=~/idsvr-7.2.0/idsvr
+export IDSVR_HOME=~/idsvr-7.3.1/idsvr
 ./create-secure-environment-data.sh
 ```
 

--- a/build.sh
+++ b/build.sh
@@ -18,7 +18,7 @@ fi
 #
 # Build the Curity Identity Server's custom Docker image
 #
-docker build -f idsvr/Dockerfile -t custom_idsvr:7.2.0 .
+docker build -f idsvr/Dockerfile -t custom_idsvr:7.3.1 .
 if [ $? -ne 0 ]; then
   echo 'Problem encountered building the Identity Server docker image'
   exit

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
   #
   curity-idsvr:
     hostname: identityserver-internal
-    image: custom_idsvr:7.2.0
+    image: custom_idsvr:7.3.1
     ports:
       - 6749:6749
       - 8443:8443

--- a/idsvr/Dockerfile
+++ b/idsvr/Dockerfile
@@ -1,4 +1,4 @@
-FROM curity.azurecr.io/curity/idsvr:7.2.0
+FROM curity.azurecr.io/curity/idsvr:7.3.1
 
 # Copy in multiple parameterized configuration files
 RUN rm -rf /opt/idsvr/etc/init/*.xml

--- a/initial-config/first-deployment.sh
+++ b/initial-config/first-deployment.sh
@@ -24,4 +24,4 @@ echo "$KEY" > "$VAULT_FOLDER/configencryption.key"
 docker run -it -p 6749:6749 -p 8443:8443 \
 -e PASSWORD='Password1' \
 -e CONFIG_ENCRYPTION_KEY="$KEY" \
-curity.azurecr.io/curity/idsvr:7.2.0
+curity.azurecr.io/curity/idsvr:7.3.1

--- a/initial-config/second-deployment.sh
+++ b/initial-config/second-deployment.sh
@@ -31,4 +31,4 @@ docker run -it -p 6749:6749 -p 8443:8443 \
 -e CONFIG_ENCRYPTION_KEY="$KEY" \
 -e ADMIN='true' \
 -v "$(pwd)/initial-config-backup.xml":/opt/idsvr/etc/init/config.xml \
-curity.azurecr.io/curity/idsvr:7.2.0
+curity.azurecr.io/curity/idsvr:7.3.1

--- a/vault/crypto/encrypt_util.sh
+++ b/vault/crypto/encrypt_util.sh
@@ -10,7 +10,7 @@ cd "$(dirname "${BASH_SOURCE[0]}")"
 # Usage of this helper module
 #
 function usage_message() {
-  echo "Usage: './encrypt_util.sh type plaintextdata encryptionkey', where type is 'plain', 'p12' or 'pem'"
+  echo "Usage: './encrypt_util.sh type plaintextdata encryptionkey', where type is 'plaintext' or 'base64keystore'"
 }
 
 #
@@ -18,7 +18,7 @@ function usage_message() {
 #
 function encrypt_plaintext() {
 
-	CLASSPATH="$IDSVR_HOME/lib/*"
+	CLASSPATH="$IDSVR_HOME/lib/*:$IDSVR_HOME/lib/xml-tools/*"
 	XML_FILE=$(mktemp)
 	XSLT_FILE=$(mktemp)
 	trap 'rm -f "$XML_FILE $XSLT_FILE"' EXIT
@@ -70,7 +70,7 @@ EOF
 #
 function encrypt_base64keystore() {
 
-	CLASSPATH="$IDSVR_HOME/lib/*"
+	CLASSPATH="$IDSVR_HOME/lib/*:$IDSVR_HOME/lib/xml-tools/*"
 	XML_FILE=$(mktemp)
 	XSLT_FILE=$(mktemp)
 	trap 'rm -f "$XML_FILE $XSLT_FILE"' EXIT


### PR DESCRIPTION
Updated to 7.3.1 where the xalan encryption namespace has changed.
Set the new CLASSPATH as suggested by Travis and tested that 7.3 encryption failed before then worked after.